### PR TITLE
Zookeeper passes correct ip over relation.

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -33,9 +33,12 @@ class ZookeeperProvides(RelationBase):
         self.remove_state('{relation_name}.ready')
         self.remove_state('{relation_name}.joined')
 
-    def send_port(self, port, rest_port):
+    def send_connection(self, port, rest_port, host=None):
         conv = self.conversation()
         conv.set_remote(data={
             'port': port,
             'rest_port': rest_port,
+            'host': host
         })
+
+    send_port = send_connection

--- a/requires.py
+++ b/requires.py
@@ -43,7 +43,7 @@ class ZookeeperRequires(RelationBase):
             port = conv.get_remote('port')
             rest_port = conv.get_remote('rest_port')
             host = conv.get_remote('host') or conv.get_remote(
-                'private_address')
+                'private-address')
             if port:
                 zks.append({
                     'host': host,

--- a/requires.py
+++ b/requires.py
@@ -42,9 +42,11 @@ class ZookeeperRequires(RelationBase):
         for conv in self.conversations():
             port = conv.get_remote('port')
             rest_port = conv.get_remote('rest_port')
+            host = conv.get_remote('host') or conv.get_remote(
+                'private_address')
             if port:
                 zks.append({
-                    'host': conv.get_remote('private-address'),
+                    'host': host,
                     'port': port,
                     'rest_port': rest_port
                 })


### PR DESCRIPTION
If we've bound Zookeeper to listen on a specific address, pass that over
the relation, rather than passing private-address.

@juju-solutions/bigdata 
